### PR TITLE
mod get_balance: if it has a short, btc balance will be returned minus

### DIFF
--- a/autotrade/driver/api/bitflyer.py
+++ b/autotrade/driver/api/bitflyer.py
@@ -10,7 +10,11 @@ class BitflyerFxApiDriver():
         collateral = api.getcollateral()
         if len(positions) > 0:
             pos = positions.pop()
-            result["BTC"] = pos['size']
+            if pos["side"] == "BUY":
+                size = float(pos['size'])
+            else:
+                size = float(pos['size']) * -1
+            result["BTC"] = size
             result["JPY"] = 0.0
         else:
             result["BTC"] = 0.0


### PR DESCRIPTION
空売りしたら balance がマイナスを示すようにした
```
% python3 worker.py  #ノーポジション
{'BTC': 0.0, 'JPY': 37191.263399616}
[owner@takahashitakuyanoMacBook] ~/.ghq/bitbucket.org/yujilow1220/autotrade/autotrade
% python3 worker.py # 0.01 の空売りポジ持ち
{'BTC': -0.01, 'JPY': 0.0}
```
あとはストラテジで読み取って