### PR TITLE
Add logger and enable the strategy to do short selling

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,3 @@
+Takuya TAKAHASHI <adgjmbehkncfilo1234@gmail.com>
+Yuki Shiga <y.shiga.91+yush1ga@gmail.com>
 takuya <info@yujilow.net>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,15 @@
 CHANGES
 =======
 
+* Add logger and enable the strategy to do short selling
+* mod get\_balance: if it has a short, btc balance will be returned minus
+* fix kusobagu
+* fix worker to print log
+* fix some fx api
+* Update bitflyer.py
+* Fix api url
+* setup setuptools
+* Fix indent
 * add strategy
 * mod requirements.txt
 * fix driver

--- a/autotrade/driver/api/bitflyer.py
+++ b/autotrade/driver/api/bitflyer.py
@@ -15,7 +15,7 @@ class BitflyerFxApiDriver():
             else:
                 size = float(pos['size']) * -1
             result["BTC"] = size
-            result["JPY"] = 0.0
+            result["JPY"] = collateral['collateral']
         else:
             result["BTC"] = 0.0
             result["JPY"] = collateral['collateral']
@@ -23,20 +23,20 @@ class BitflyerFxApiDriver():
 
     def execute(self, strategy_result):
         return getattr(self, strategy_result.get('action'))(strategy_result.get('amount'))
-    
+
     def buy(self, amount):
         api = pybitflyer.API(api_key=os.environ['API_KEY'], api_secret=os.environ['API_SECRET'])
         r = api.sendchildorder(product_code="FX_BTC_JPY",
                        child_order_type="MARKET",
                        side="BUY",
-                       size=round(self.jpy_to_size("FX_BTC", amount), 4),
+                       size=amount,
                        minute_to_expire=10000,
                        time_in_force="GTC"
                        )
         print(round(self.jpy_to_size("FX_BTC", amount), 4))
         print(r)
         return r
-    
+
     def sell(self, amount):
         api = pybitflyer.API(api_key=os.environ['API_KEY'], api_secret=os.environ['API_SECRET'])
         r = api.sendchildorder(product_code="FX_BTC_JPY",
@@ -51,7 +51,7 @@ class BitflyerFxApiDriver():
     def nothing(self, amount):
         print("nothing")
         return 200
-    
+
     def jpy_to_size(self, currency, price):
         api = pybitflyer.API()
         ticker =  api.ticker(product_code="%s_JPY" % currency)
@@ -68,7 +68,7 @@ class BitflyerApiDriver():
 
     def execute(self, strategy_result):
         return getattr(self, strategy_result.get('action'))(strategy_result.get('amount'))
-    
+
     def buy(self, amount):
         api = pybitflyer.API(api_key=os.environ['API_KEY'], api_secret=os.environ['API_SECRET'])
         r = api.sendchildorder(product_code="FX_BTC_JPY",
@@ -79,7 +79,7 @@ class BitflyerApiDriver():
                        time_in_force="GTC"
                        )
         return r.status_code
-    
+
     def sell(self, amount):
         api = pybitflyer.API(api_key=os.environ['API_KEY'], api_secret=os.environ['API_SECRET'])
         r = api.sendchildorder(product_code="FX_BTC_JPY",
@@ -94,7 +94,7 @@ class BitflyerApiDriver():
     def nothing(self):
         print("nothing")
         return 200
-    
+
     def jpy_to_size(self, currency, price):
         api = pybitflyer.API()
         ticker =  api.ticker(product_code="%s_JPY" % currency)


### PR DESCRIPTION
各アクションの時に反対の建玉があれば解消、なければJPYをbtcに変換した値を投げる
たぶん、建玉解消の1分後にはまた建玉生やしちゃうから常に建玉を持ってるスリリングな運用になります