### PR TITLE
encode unicode to utf-8 for python3

### DIFF
--- a/autotrade/driver/api/bitflyer.py
+++ b/autotrade/driver/api/bitflyer.py
@@ -74,7 +74,7 @@ class BitflyerFxApiDriver():
         board = api.board(product_code="FX_BTC_JPY")
         positions = api.getpositions(product_code="FX_BTC_JPY")
         if len(positions) > 0:
-            trade_id = hashlib.sha256(''.join([p['open_date'] for p in positions])).hexdigest()[0:20]
+            trade_id = hashlib.sha256(''.join([p['open_date'] for p in positions]).encode('utf-8')).hexdigest()[0:20]
             position = positions.pop()
             if position.get("side") == "BUY":
                 profit = (float(board.get("mid_price")) - float(position.get("price"))) * float(position.get("size"))
@@ -83,7 +83,7 @@ class BitflyerFxApiDriver():
         else:
             position = None
             profit = None
-            trade_id = hashlib.sha256(str(datetime.now())).hexdigest()[0:20]
+            trade_id = hashlib.sha256(str(datetime.now()).encode('utf-8')).hexdigest()[0:20]
         return trade_id, action_json, board.get("mid_price"), position, profit
 
 


### PR DESCRIPTION
python3では、hashlib は utf-8 にエンコードしないといけないらしいのでやりました。